### PR TITLE
Use scout_level for webhook when PGScout is used

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -2116,6 +2116,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                     'rating_attack': scout_result['rating_attack'],
                     'rating_defense': scout_result['rating_defense'],
                 })
+                encounter_level = scout_result['scout_level']
             # We need to check if exist and is not false due to a request error
             elif pokemon_info:
                 pokemon[p.encounter_id].update({


### PR DESCRIPTION
Use scout_level for webhook when PGScout is used.
Currently, the webhook use the scan account level for the webhook.
