### PR TITLE
check for ditto before encounter

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -2074,6 +2074,14 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                 filtered += 1
                 continue
 
+            # Catch pokemon to check for Ditto if --gain-xp enabled
+            # Original code by voxx!
+            have_balls = pgacc.inventory_balls > 0
+            if args.gain_xp and not pgacc.get_stats(
+                'level') >= 30 and pokemon_id in DITTO_CANDIDATES_IDS and have_balls:
+                if is_ditto(args, pgacc, p):
+                    pokemon_id = 132
+
             printPokemon(pokemon_id, p.latitude, p.longitude,
                          disappear_time)
 
@@ -2113,17 +2121,8 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                 'rating_defense': None
             }
 
-            # Catch pokemon to check for Ditto if --gain-xp enabled
-            # Original code by voxx!
-            have_balls = pgacc.inventory_balls > 0
-            if args.gain_xp and not pgacc.get_stats(
-                'level') >= 30 and pokemon_id in DITTO_CANDIDATES_IDS and have_balls:
-                if is_ditto(args, pgacc, p):
-                    pokemon[p.encounter_id]['pokemon_id'] = 132
-                    pokemon_id = 132
-                    pokemon_info = None
             # Check for Unown's alphabetic character.
-            elif pokemon_id == 201:
+            if pokemon_id == 201:
                 pokemon[p.encounter_id]['form'] = (p.pokemon_data
                                                     .pokemon_display.form)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Moved the ditto check for Pokemon before the encounter code. This will allow Dittos to correctly be encountered if set in encounter whitelist and gain-xp is enabled.

## Motivation and Context
As above, to properly check IVs for Dittos who were ignored before.

## How Has This Been Tested?
Tested on a live RocketMap branch, code up to date with latest MIX_MEWTWO

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
