### PR TITLE
On Demand Scout of Pokemon with known IV/CP

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -672,6 +672,9 @@ function pokemonLabel(item) {
             <div class='pokemon links'>
               <i class='fa fa-lg fa-fw fa-trash-o'></i> <a href='javascript:removePokemonMarker("${encounterId}")'>Remove</a>
             </div>
+            <div class='pokemon links'>
+              <i class='fa fa-2x fa-binoculars'></i>&nbsp; <a href='javascript:scout("${encounterId}")'>Re-Scout</a>
+          </div>
           </div>
       </div>
       <div class='pokemon container content-right'>

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -631,6 +631,9 @@ function pokemonLabel(item) {
                 <div class='pokemon links'>
                   <i class='fa fa-lg fa-fw fa-trash-o'></i> <a href='javascript:removePokemonMarker("${encounterId}")'>Remove</a>
                 </div>
+                <div class='pokemon links'>
+                  <i class='fa fa-lg fa-fw fa-binoculars'></i> <a href='javascript:scout("${encounterId}")'>Scout</a>
+                </div>
               </div>
           </div>
           <div class='pokemon container content-right'>
@@ -672,9 +675,6 @@ function pokemonLabel(item) {
             <div class='pokemon links'>
               <i class='fa fa-lg fa-fw fa-trash-o'></i> <a href='javascript:removePokemonMarker("${encounterId}")'>Remove</a>
             </div>
-            <div class='pokemon links'>
-              <i class='fa fa-2x fa-binoculars'></i>&nbsp; <a href='javascript:scout("${encounterId}")'>Re-Scout</a>
-          </div>
           </div>
       </div>
       <div class='pokemon container content-right'>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This adds the Scout button on the left content pane of pokemon that already have CP/IV information to allow them to be rescouted

## Motivation and Context
Pokemon can have a different IV when the weather changes on the hour. Re-scanning them is necessary to update the IVs.

## How Has This Been Tested?
I have tested the feature does not break not map, but would need more confirmation to ensure it updates the Pokemon information. More help would be appreciated

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/9146812/33910980-b0a873e8-df5e-11e7-8c2a-cdd80e010e68.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x  ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
