### PR TITLE
Send weather condition to PGScout

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1885,6 +1885,7 @@ def perform_pgscout(p):
     pkm.spawnpoint_id = p.spawn_point_id
     pkm.latitude = p.latitude
     pkm.longitude = p.longitude
+    pkm.weather_boosted_condition = p.pokemon_data.pokemon_display.weather_boosted_condition
     scout_result = pgscout_encounter(pkm)
     if scout_result['success']:
         log.info(

--- a/pogom/pgscout.py
+++ b/pogom/pgscout.py
@@ -25,7 +25,8 @@ def pgscout_encounter(p):
         'encounter_id': p.encounter_id,
         'spawn_point_id': p.spawnpoint_id,
         'latitude': p.latitude,
-        'longitude': p.longitude
+        'longitude': p.longitude,
+        'weather': p.weather_boosted_condition
     }
     try:
         r = requests.get(args.pgscout_url, params=params)

--- a/pogom/webhook.py
+++ b/pogom/webhook.py
@@ -209,7 +209,7 @@ def __get_key_fields(whtype):
             'spawnpoint_id', 'pokemon_id', 'latitude', 'longitude',
             'disappear_time', 'move_1', 'move_2', 'individual_stamina',
             'individual_defense', 'individual_attack', 'form', 'cp',
-            'pokemon_level'
+            'pokemon_level', 'weather'
         ],
         'gym': [
             'team_id', 'guard_pokemon_id', 'enabled', 'latitude', 'longitude',

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -502,14 +502,15 @@ function getDateStr(t) {
     return dateStr
 }
 
-function scout(encounterId) { // eslint-disable-line no-unused-vars
+function scout(encounterId, weather) { // eslint-disable-line no-unused-vars
     var infoEl = $('#scoutInfo' + atob(encounterId))
-
+    weather = weather || '0'
     $.ajax({
         url: 'scout',
         type: 'GET',
         data: {
-            'encounter_id': encounterId
+            'encounter_id': encounterId,
+            'weather': weather
         },
         dataType: 'json',
         cache: false,
@@ -700,7 +701,7 @@ function pokemonLabel(item) {
           </div>
           ${weatherBoost}
           <div class='pokemon links'>
-            <i class='fa fa-2x fa-binoculars'></i>&nbsp; <a href='javascript:scout("${encounterId}")'>Scout for IV / CP / Moves</a>
+            <i class='fa fa-2x fa-binoculars'></i>&nbsp; <a href='javascript:scout("${encounterId}", "${weather_boosted_condition}")'>Scout for IV / CP / Moves</a>
           </div>
           <div class='pokemon'>
             <span class='pokemon navigate'><a href='javascript:void(0);' onclick='javascript:openMapDirections(${latitude},${longitude});' title='Open in Google Maps'>${latitude.toFixed(6)}, ${longitude.toFixed(7)}</a></span>

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -502,15 +502,13 @@ function getDateStr(t) {
     return dateStr
 }
 
-function scout(encounterId, weather) { // eslint-disable-line no-unused-vars
+function scout(encounterId) { // eslint-disable-line no-unused-vars
     var infoEl = $('#scoutInfo' + atob(encounterId))
-    weather = weather || '0'
     $.ajax({
         url: 'scout',
         type: 'GET',
         data: {
-            'encounter_id': encounterId,
-            'weather': weather
+            'encounter_id': encounterId
         },
         dataType: 'json',
         cache: false,
@@ -701,7 +699,7 @@ function pokemonLabel(item) {
           </div>
           ${weatherBoost}
           <div class='pokemon links'>
-            <i class='fa fa-2x fa-binoculars'></i>&nbsp; <a href='javascript:scout("${encounterId}", "${weather_boosted_condition}")'>Scout for IV / CP / Moves</a>
+            <i class='fa fa-2x fa-binoculars'></i>&nbsp; <a href='javascript:scout("${encounterId}")'>Scout for IV / CP / Moves</a>
           </div>
           <div class='pokemon'>
             <span class='pokemon navigate'><a href='javascript:void(0);' onclick='javascript:openMapDirections(${latitude},${longitude});' title='Open in Google Maps'>${latitude.toFixed(6)}, ${longitude.toFixed(7)}</a></span>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This will send weather_boosted_condition to PGScout encounters to properly cache the Pokemon

## Motivation and Context
With the weather changes it is necessary to keep track of the weather the pokemon was scanned under because the Pokemon IVs may change if the weather changes.

## How Has This Been Tested?
Tested on my production server.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

Integrates with https://github.com/sLoPPydrive/PGScout/pull/33