### PR TITLE
Fixed duplicate Psychic

### DIFF
--- a/static/locales/de.json
+++ b/static/locales/de.json
@@ -943,7 +943,6 @@
   "Psychic Fangs": "Psychobeißer",
   "Psychic Terrain": "Psychofeld",
   "Psychic": "Psycho",
-  "Psychic": "Psychokinese",
   "Psycho Boost": "Psyschub",
   "Psycho Cut": "Psychoklinge",
   "Psycho Shift": "Psybann",


### PR DESCRIPTION
I had accidentally re-introduced the wrong german translation for Psychic in #18, this fixes it.